### PR TITLE
Import + Use Product model when populating cart products

### DIFF
--- a/pages/api/cart.js
+++ b/pages/api/cart.js
@@ -1,6 +1,7 @@
 import mongoose from "mongoose";
 import jwt from "jsonwebtoken";
 import Cart from "../../models/Cart";
+import Product from "../../models/Product";
 import connectDb from "../../utils/connectDb";
 
 connectDb();
@@ -38,7 +39,7 @@ async function handleGetRequest(req, res) {
     );
     const cart = await Cart.findOne({ user: userId }).populate({
       path: "products.product",
-      model: "Product"
+      model: Product
     });
     res.status(200).json(cart.products);
   } catch (error) {


### PR DESCRIPTION
This is a followup to the issue you showed me during class today.

The full error message can be viewed at zeit.co, under the project's logs. It'll go like this:

```
MissingSchemaError: Schema hasn't been registered for model "Product".
Use mongoose.model(name, schema)
    at new MissingSchemaError (/var/task/node_modules/mongoose/lib/error/missingSchema.js:22:11)
    at NativeConnection.Connection.model (/var/task/node_modules/mongoose/lib/connection.js:1029:11)
```

I suggested that the problem had to do with the `populate` call in this function, and I was right.

I thought about it some more tonight and tinkered with it. What's happening here is that each Zeit/Now request is ran inside it's own... let's call it a container. When we hit the `/api/cart.js` endpoint, it'll load the `api/cart.js` file _and anything that file imports_ into the "context" for that container. Because this file _did not_ import `Product`, it was therefore unable to find the "Product" schema when it needed it.

To fix this problem, it's a two-stepper:

1. Import `Product` at the top of this file. This will define the `Product` model, which is the first thing our error is complaining about. 
2. Because importing this will leave an unused value at the top of your file and code linters will complain about that... we need to use `Product` in the populate call. Mongoose is smart enough to know what to do if we pass it `Product` instead of `"Product"`. There's at least one example of this in their [populate](https://mongoosejs.com/docs/populate.html) documentation.

This was a bit tricky for me to get my head around because I'm used to working within Rails applications where _everything_ is loaded all-at-once and is available _everywhere_. I guess we both just have to be careful that when we're over here in JS land that things are only loaded _if we have imported them_.